### PR TITLE
Add check android camera permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ For more info about resolveAssetSource refer to the online React documentation.
 
 ## CvCamera
 
-`CvCamera` is a React Native component that displays the front or back facing camera view and can be wrapped in CvInvoke tags.  The innermost CvInvoke tag should reference either 'rgba', 'rgbat', 'gray' or 'grayt' as the first parameter 'p1' in the params dictionary property.  The optional `facing` property should be set to either 'front' the default for the camera view away from the user or 'back' for towards the user.  The optional `androidCameraPermissionOptions` property lets you change the text for the camera permissions prompt on Android.
+`CvCamera` is a React Native component that displays the front or back facing camera view and can be wrapped in CvInvoke tags.  The innermost CvInvoke tag should reference either 'rgba', 'rgbat', 'gray' or 'grayt' as the first parameter 'p1' in the params dictionary property.  The optional `facing` property should be set to either 'front' the default for the camera view away from the user or 'back' for towards the user.  
 
 The optional `onFrameSize` property refers to the callback that gets the frame size information.  The information is returned to the callback in the json dictionary format: `{ "payload" : { "frameSize" : { "frameWidth" : XXX, "frameHeight" : YYY }}}`.  The callback in your app should also be called `onFrameSize`.
-
+   
 Basic Usage Example:
 ```javascript
 import {CvCamera, CvScalar, Mat, CvInvoke, CvInvokeGroup} from 'react-native-opencv3';
@@ -204,12 +204,6 @@ import {CvCamera, CvScalar, Mat, CvInvoke, CvInvokeGroup} from 'react-native-ope
     ref={ref => { this.cvCamera = ref }}
     style={styles.preview}
     facing={facing}
-    androidCameraPermissionOptions={{
-      title: 'Permission to use camera',
-      message: 'We need your permission to use your camera',
-      buttonPositive: 'Ok',
-      buttonNegative: 'Cancel',
-    }}
   />
 </CvInvokeGroup>
 

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ For more info about resolveAssetSource refer to the online React documentation.
 
 ## CvCamera
 
-`CvCamera` is a React Native component that displays the front or back facing camera view and can be wrapped in CvInvoke tags.  The innermost CvInvoke tag should reference either 'rgba', 'rgbat', 'gray' or 'grayt' as the first parameter 'p1' in the params dictionary property.  The optional `facing` property should be set to either 'front' the default for the camera view away from the user or 'back' for towards the user.  
+`CvCamera` is a React Native component that displays the front or back facing camera view and can be wrapped in CvInvoke tags.  The innermost CvInvoke tag should reference either 'rgba', 'rgbat', 'gray' or 'grayt' as the first parameter 'p1' in the params dictionary property.  The optional `facing` property should be set to either 'front' the default for the camera view away from the user or 'back' for towards the user.  The optional `androidCameraPermissionOptions` property lets you change the text for the camera permissions prompt on Android.
 
 The optional `onFrameSize` property refers to the callback that gets the frame size information.  The information is returned to the callback in the json dictionary format: `{ "payload" : { "frameSize" : { "frameWidth" : XXX, "frameHeight" : YYY }}}`.  The callback in your app should also be called `onFrameSize`.
-   
+
 Basic Usage Example:
 ```javascript
 import {CvCamera, CvScalar, Mat, CvInvoke, CvInvokeGroup} from 'react-native-opencv3';
@@ -204,6 +204,12 @@ import {CvCamera, CvScalar, Mat, CvInvoke, CvInvokeGroup} from 'react-native-ope
     ref={ref => { this.cvCamera = ref }}
     style={styles.preview}
     facing={facing}
+    androidCameraPermissionOptions={{
+      title: 'Permission to use camera',
+      message: 'We need your permission to use your camera',
+      buttonPositive: 'Ok',
+      buttonNegative: 'Cancel',
+    }}
   />
 </CvInvokeGroup>
 

--- a/index.js
+++ b/index.js
@@ -20,22 +20,15 @@ class CvCamera extends Component {
   constructor(props) {
     super(props)
     this.cvCamera = React.createRef()
-    if (Platform.OS === 'android' && !PermissionsAndroid.PERMISSIONS.CAMERA) this.requestCameraPermission()
+    if (Platform.OS === 'android') this.requestCameraPermission()
     this.state = {
       cameraPermissed: Platform.OS === 'ios' ? true : PermissionsAndroid.PERMISSIONS.CAMERA
     }
   }
   async requestCameraPermission() {
-    const defaultOptions = {
-      title: 'Permission to use camera',
-      message: 'We need your permission to use your camera',
-      buttonPositive: 'Ok',
-      buttonNegative: 'Cancel',
-    }
     try {
       const granted = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.CAMERA,
-        this.props.androidCameraPermissionOptions || defaultOptions,
+        PermissionsAndroid.PERMISSIONS.CAMERA
       )
       if (granted === PermissionsAndroid.RESULTS.GRANTED) {
         this.setState({cameraPermissed:true})

--- a/index.js
+++ b/index.js
@@ -93,8 +93,7 @@ class CvCamera extends Component {
 
 CvCamera.propTypes = {
   ...View.propTypes,
-  facing: PropTypes.string,
-  androidCameraPermissionOptions: PropTypes.object
+  facing: PropTypes.string
 };
 
 class CvInvokeGroup extends Component {


### PR DESCRIPTION
Dangerous permissions on Android must be prompted in the app for permissions, I believe from api level 23. Adding permissions to AndroidManifest.xml does not suffice. If camera permissions are not given in this way then CvCamera automatically closes the app. I could not run the example apps without adding this.

This solution on Android first shows an empty view instead of CvCamera component and prompts the user for permissions.

This should have no effect on iOS but I am unable to test on iOS at the moment.